### PR TITLE
💩 [Package] `@beefchimi` scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 17.x
           # Requires `scope` and `url` so I can install my
           # private `@beefchimi` dependencies.
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://npm.pkg.github.com
           scope: '@beefchimi'
 
       - name: Install dependencies and build (with cache)
@@ -31,6 +31,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          registry-url: https://registry.npmjs.org
+          scope: '@beefchimi'
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# socialite
+# @beefchimi/socialite
 
 ## 0.0.1
+
 ### Patch Changes
 
-- 3d7badd: Prepare Socialite for initial release.
+- [#1](https://github.com/beefchimi/socialite/pull/1) [`25db0ed`](https://github.com/beefchimi/socialite/commit/25db0ed1a02385e9e9402369680114b8e1d9d12a): Prepare Socialite for initial release.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Simply install via the command-line or include in your `package.json`, just like
 
 ```sh
 # Alternatively install with `yarn` or `pnpm`
-npm install socialite
+npm install @beefchimi/socialite
 ```
 
 ## How to use
@@ -28,7 +28,7 @@ npm install socialite
 By default, `Socialite` includes only a small collection of the most common social networks. A typical use case looks like:
 
 ```ts
-import {Socialite} from 'socialite';
+import {Socialite} from '@beefchimi/socialite';
 
 const socialiteInstance = new Socialite();
 const mySocialUrl = 'https://www.twitter.com/@SomeFakeUserHandle';
@@ -61,7 +61,7 @@ The above will log the following `SocialProfile` _(object)_ to the console:
 For a more robust collection of social networks, you can import and pass in `allSocialNetworks`:
 
 ```ts
-import {Socialite, allSocialNetworks} from 'socialite';
+import {Socialite, allSocialNetworks} from '@beefchimi/socialite';
 
 const socialiteInstance = new Socialite(allSocialNetworks);
 console.log(socialiteInstance.getNetworks());

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "socialite",
+  "name": "@beefchimi/socialite",
   "version": "0.0.1",
   "description": "Social network URL parsing for aristocrats ",
   "author": "Curtis Dulmage",


### PR DESCRIPTION
Well I guess `socialite` already exists and is basically a useless package published once 5 years ago by an account that doesn't even exist anymore...

Oh well. Let's just scope this and go home.