### PR TITLE
💥 [YouTube] No longer support short url

### DIFF
--- a/.changeset/hot-coins-shop.md
+++ b/.changeset/hot-coins-shop.md
@@ -1,0 +1,5 @@
+---
+'socialitejs': patch
+---
+
+No longer matching against YouTube short urls, since they do not link to channels.

--- a/src/networks/tests/youtube.test.ts
+++ b/src/networks/tests/youtube.test.ts
@@ -26,8 +26,8 @@ describe('Social networks > youtube', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when using the short url', () => {
-    const mockUncommonUrl = `https://youtu.be/c/${mockGenericUser}`;
+  it('returns expected `id` and `user` when provided app url', () => {
+    const mockUncommonUrl = `https://m.youtube.com/c/${mockGenericUser}/`;
     const {id, user} = mockSocialite.parseProfile(
       mockUncommonUrl,
     ) as SocialiteProfile;
@@ -36,13 +36,10 @@ describe('Social networks > youtube', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when leading path is absent', () => {
-    const mockUncommonUrl = `https://youtube.com/${mockGenericUser}/`;
-    const {id, user} = mockSocialite.parseProfile(
-      mockUncommonUrl,
-    ) as SocialiteProfile;
+  it('does not match against the short url', () => {
+    const mockUncommonUrl = `https://youtu.be/c/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(mockUncommonUrl);
 
-    expect(id).toBe(youtube.id);
-    expect(user).toBe(mockGenericUser);
+    expect(match).toBe(false);
   });
 });

--- a/src/networks/youtube.ts
+++ b/src/networks/youtube.ts
@@ -6,11 +6,10 @@ export const youtube: SocialiteNetwork = {
   preferredUrl: `https://youtube.com/channel/${profileReplacement.user}`,
   appUrl: `https://m.youtube.com/c/${profileReplacement.user}`,
   matcher: {
-    // `youtu.be` URLs do not currently support user channels.
-    // We are capturing that anyways... in case this changes in the future.
-    domain: /youtu/,
-    // YouTube has a legacy `/user/*` URL.
-    // We do not support this at the moment... but might reconsider.
-    user: /^(?:\/channel\/|\/c\/)?(?:\/)?([^/]+)/,
+    // TODO: Worth considering if we match against short URLs.
+    // https://github.com/beefchimi/socialite/issues/21
+    domain: /youtube/,
+    // Not currently supporting the legacy `/user/*` URL.
+    user: /^\/(?:channel|c)\/([^/]+)/,
   },
 };


### PR DESCRIPTION
I am tightening up our criteria for matching against `youtube` handles.