### PR TITLE
💥 [Networks] Stricter pattern matching for leading directories

### DIFF
--- a/.changeset/kind-panthers-pretend.md
+++ b/.changeset/kind-panthers-pretend.md
@@ -1,0 +1,5 @@
+---
+'socialitejs': patch
+---
+
+Stricter pattern matching for all networks with a leading path.

--- a/src/networks/discord.ts
+++ b/src/networks/discord.ts
@@ -6,6 +6,6 @@ export const discord: SocialiteNetwork = {
   preferredUrl: `https://discordapp.com/users/${profileReplacement.user}`,
   matcher: {
     domain: /discord/,
-    user: /^(?:\/users\/)?(?:\/)?([^/]+)/,
+    user: /^(?:\/users\/)([^/]+)/,
   },
 };

--- a/src/networks/exercism.ts
+++ b/src/networks/exercism.ts
@@ -6,6 +6,6 @@ export const exercism: SocialiteNetwork = {
   preferredUrl: `https://exercism.io/profiles/${profileReplacement.user}`,
   matcher: {
     domain: /exercism/,
-    user: /^(?:\/profiles\/)?(?:\/)?([^/]+)/,
+    user: /^(?:\/profiles\/)([^/]+)/,
   },
 };

--- a/src/networks/linkedin.ts
+++ b/src/networks/linkedin.ts
@@ -7,6 +7,6 @@ export const linkedin: SocialiteNetwork = {
   appUrl: `https://linkedin.com/mwlite/in/${profileReplacement.user}`,
   matcher: {
     domain: /linkedin/,
-    user: /^(?:\/mwlite\/)?(?:[/]?in\/)?(?:\/)?([^/]+)/,
+    user: /^\/(?:mwlite|in)\/([^/]+)/,
   },
 };

--- a/src/networks/reddit.ts
+++ b/src/networks/reddit.ts
@@ -6,6 +6,6 @@ export const reddit: SocialiteNetwork = {
   preferredUrl: `https://reddit.com/user/${profileReplacement.user}`,
   matcher: {
     domain: /reddit/,
-    user: /^(?:\/user\/)?(?:\/)?([^/]+)/,
+    user: /^(?:\/user\/)([^/]+)/,
   },
 };

--- a/src/networks/stackoverflow.ts
+++ b/src/networks/stackoverflow.ts
@@ -6,6 +6,6 @@ export const stackoverflow: SocialiteNetwork = {
   preferredUrl: `https://stackoverflow.com/users/${profileReplacement.user}`,
   matcher: {
     domain: /stackoverflow/,
-    user: /^(?:\/users\/)?(?:[/]?\d+)?(?:\/)?([^/]+)/,
+    user: /^(?:\/users\/)(?:\d+?[/])?([^/]+)/,
   },
 };

--- a/src/networks/tests/discord.test.ts
+++ b/src/networks/tests/discord.test.ts
@@ -26,13 +26,13 @@ describe('Social networks > discord', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when leading path is absent', () => {
-    const mockUncommonUrl = `https://discordapp.com/${mockGenericUser}/`;
-    const {id, user} = mockSocialite.parseProfile(
-      mockUncommonUrl,
+  it('returns `id` with no `user` when provided an unrecognized leading path', () => {
+    const mockUnsupportedUrl = `https://discordapp.com/foo/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(
+      mockUnsupportedUrl,
     ) as SocialiteProfile;
 
-    expect(id).toBe(discord.id);
-    expect(user).toBe(mockGenericUser);
+    expect(match.id).toBe(discord.id);
+    expect(match.user).toBeUndefined();
   });
 });

--- a/src/networks/tests/exercism.test.ts
+++ b/src/networks/tests/exercism.test.ts
@@ -26,13 +26,13 @@ describe('Social networks > exercism', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when leading path is absent', () => {
-    const mockUncommonUrl = `https://exercism.io/${mockGenericUser}/`;
-    const {id, user} = mockSocialite.parseProfile(
-      mockUncommonUrl,
+  it('returns `id` with no `user` when provided an unrecognized leading path', () => {
+    const mockUnsupportedUrl = `https://exercism.io/foo/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(
+      mockUnsupportedUrl,
     ) as SocialiteProfile;
 
-    expect(id).toBe(exercism.id);
-    expect(user).toBe(mockGenericUser);
+    expect(match.id).toBe(exercism.id);
+    expect(match.user).toBeUndefined();
   });
 });

--- a/src/networks/tests/linkedin.test.ts
+++ b/src/networks/tests/linkedin.test.ts
@@ -26,8 +26,8 @@ describe('Social networks > linkedin', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when url is from mobile app', () => {
-    const mockUncommonUrl = `https://linkedin.com/mwlite/in/${mockGenericUser}`;
+  it('returns expected `id` and `user` when provided app url', () => {
+    const mockUncommonUrl = `https://linkedin.com/mwlite/${mockGenericUser}`;
     const {id, user} = mockSocialite.parseProfile(
       mockUncommonUrl,
     ) as SocialiteProfile;
@@ -36,13 +36,13 @@ describe('Social networks > linkedin', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when leading path is absent', () => {
-    const mockUncommonUrl = `https://linkedin.com/${mockGenericUser}/`;
-    const {id, user} = mockSocialite.parseProfile(
-      mockUncommonUrl,
+  it('returns `id` with no `user` when provided an unrecognized leading path', () => {
+    const mockUnsupportedUrl = `https://linkedin.com/foo/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(
+      mockUnsupportedUrl,
     ) as SocialiteProfile;
 
-    expect(id).toBe(linkedin.id);
-    expect(user).toBe(mockGenericUser);
+    expect(match.id).toBe(linkedin.id);
+    expect(match.user).toBeUndefined();
   });
 });

--- a/src/networks/tests/reddit.test.ts
+++ b/src/networks/tests/reddit.test.ts
@@ -26,13 +26,13 @@ describe('Social networks > reddit', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when leading path is absent', () => {
-    const mockUncommonUrl = `https://reddit.com/${mockGenericUser}/`;
-    const {id, user} = mockSocialite.parseProfile(
-      mockUncommonUrl,
+  it('returns `id` with no `user` when provided an unrecognized leading path', () => {
+    const mockUnsupportedUrl = `https://reddit.com/foo/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(
+      mockUnsupportedUrl,
     ) as SocialiteProfile;
 
-    expect(id).toBe(reddit.id);
-    expect(user).toBe(mockGenericUser);
+    expect(match.id).toBe(reddit.id);
+    expect(match.user).toBeUndefined();
   });
 });

--- a/src/networks/tests/stackoverflow.test.ts
+++ b/src/networks/tests/stackoverflow.test.ts
@@ -26,13 +26,23 @@ describe('Social networks > stackoverflow', () => {
     expect(user).toBe(mockGenericUser);
   });
 
-  it('returns expected `id` and `user` when leading path is absent', () => {
-    const mockUncommonUrl = `https://stackoverflow.com/${mockGenericUser}/`;
+  it('returns expected `id` and `user` when digits path is present', () => {
+    const mockUncommonUrl = `https://stackoverflow.com/users/1234567890/${mockGenericUser}/`;
     const {id, user} = mockSocialite.parseProfile(
       mockUncommonUrl,
     ) as SocialiteProfile;
 
     expect(id).toBe(stackoverflow.id);
     expect(user).toBe(mockGenericUser);
+  });
+
+  it('returns `id` with no `user` when provided an unrecognized leading path', () => {
+    const mockUnsupportedUrl = `https://stackoverflow.com/foo/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(
+      mockUnsupportedUrl,
+    ) as SocialiteProfile;
+
+    expect(match.id).toBe(stackoverflow.id);
+    expect(match.user).toBeUndefined();
   });
 });

--- a/src/networks/tests/youtube.test.ts
+++ b/src/networks/tests/youtube.test.ts
@@ -37,9 +37,19 @@ describe('Social networks > youtube', () => {
   });
 
   it('does not match against the short url', () => {
-    const mockUncommonUrl = `https://youtu.be/c/${mockGenericUser}`;
-    const match = mockSocialite.parseProfile(mockUncommonUrl);
+    const mockShortUrl = `https://youtu.be/c/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(mockShortUrl);
 
     expect(match).toBe(false);
+  });
+
+  it('returns `id` with no `user` when provided an unrecognized leading path', () => {
+    const mockUnsupportedUrl = `https://youtube.com/foo/${mockGenericUser}`;
+    const match = mockSocialite.parseProfile(
+      mockUnsupportedUrl,
+    ) as SocialiteProfile;
+
+    expect(match.id).toBe(youtube.id);
+    expect(match.user).toBeUndefined();
   });
 });


### PR DESCRIPTION
I was too loose with my previous matching for any network with a `/path/` preceding its `user`. I am not being more strict.