### PR TITLE
✨ [Socialite] New methods and one renamed method

### DIFF
--- a/.changeset/fast-carpets-hang.md
+++ b/.changeset/fast-carpets-hang.md
@@ -1,0 +1,5 @@
+---
+'socialitejs': patch
+---
+
+Added `getNetwork()` and `getPreferredUrl()` methods. Also renamed `getNetworks()` to `getAllNetworks()`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import type {SocialiteId} from 'socialitejs';
 const allNetworksInstance = new Socialite(Object.values(socialiteNetworks));
 
 // Logs to the console all social networks included in the code base.
-console.log(allNetworksInstance.getNetworks());
+console.log(allNetworksInstance.getAllNetworks());
 
 // Initializing `Socialite` without any networks (pass empty `array`):
 const selectiveNetworksInstance = new Socialite([]);
@@ -81,7 +81,7 @@ Object.keys(socialiteNetworks).forEach((network) => {
 });
 
 // Logs to the console all social networks not found in `excludedNetworks`.
-console.log(selectiveNetworksInstance.getNetworks());
+console.log(selectiveNetworksInstance.getAllNetworks());
 ```
 
 ## Features

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   filterNetworkProperties,
   mergeRegExp,
   getUrlGroups,
+  getUrlWithSubstitutions,
 } from './utilities';
 
 export {MatchUserSource, UrlCaptureId} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ export {
   filterNetworkProperties,
   mergeRegExp,
   getUrlGroups,
-  getUrlWithSubstitutions,
 } from './utilities';
 
 export {MatchUserSource, UrlCaptureId} from './types';

--- a/src/tests/socialite.test.ts
+++ b/src/tests/socialite.test.ts
@@ -11,19 +11,23 @@ describe('Socialite class instance', () => {
 
   it('contains the default networks', () => {
     const mockSocialite = new Socialite();
-    expect(mockSocialite.getNetworks()).toStrictEqual(defaultSocialiteNetworks);
+    expect(mockSocialite.getAllNetworks()).toStrictEqual(
+      defaultSocialiteNetworks,
+    );
   });
 
   it('constructor argument overwrites the default networks', () => {
     const mockSocialite = new Socialite(mockCustomNetworks);
-    expect(mockSocialite.getNetworks()).toStrictEqual(mockCustomNetworks);
+    expect(mockSocialite.getAllNetworks()).toStrictEqual(mockCustomNetworks);
   });
 
   it('constructor argument ignores an empty array', () => {
     const mockNetworks: SocialiteNetwork[] = [];
     const mockSocialite = new Socialite(mockNetworks);
 
-    expect(mockSocialite.getNetworks()).toStrictEqual(defaultSocialiteNetworks);
+    expect(mockSocialite.getAllNetworks()).toStrictEqual(
+      defaultSocialiteNetworks,
+    );
   });
 
   describe('fixUrlScheme()', () => {


### PR DESCRIPTION
I am adding two new methods:
1. `getNetwork()`
2. `getPreferredUrl()`

I've also renamed `getNetworks` to `getAllNetworks` to avoid confusion.

I have refrained from removing `getUrlWithSubstitutions()` from the global exports. This function can still be useful for transforming an `appUrl`... although it is worth considering if we add a `getAppUrl()` method in the future.