### PR TITLE
✨ [Socialite] Make `getNetworkFromDomain()` a public method

### DIFF
--- a/.changeset/wicked-badgers-add.md
+++ b/.changeset/wicked-badgers-add.md
@@ -1,0 +1,5 @@
+---
+'socialitejs': patch
+---
+
+Made previously private `getNetworkFromDomain()` a public method.

--- a/src/socialite.ts
+++ b/src/socialite.ts
@@ -63,6 +63,21 @@ export class Socialite {
     );
   }
 
+  getNetworkFromDomain(domain: string) {
+    let matchedNetwork: SocialiteNetwork | undefined;
+
+    for (const [_id, network] of this._networks) {
+      const match = new RegExp(network.matcher.domain).test(domain);
+
+      if (match) {
+        matchedNetwork = network;
+        break;
+      }
+    }
+
+    return matchedNetwork;
+  }
+
   getPreferredUrl(id: NetworkId, user?: UserName) {
     if (!this.hasNetwork(id)) {
       return false;
@@ -182,21 +197,6 @@ export class Socialite {
     // we for sure have an object with `domain` and `tldomain`.
     // https://github.com/beefchimi/socialite/issues/5
     return Boolean(groups?.domain && groups?.tldomain);
-  }
-
-  private getNetworkFromDomain(domain: string) {
-    let matchedNetwork: SocialiteNetwork | undefined;
-
-    for (const [_id, network] of this._networks) {
-      const match = new RegExp(network.matcher.domain).test(domain);
-
-      if (match) {
-        matchedNetwork = network;
-        break;
-      }
-    }
-
-    return matchedNetwork;
   }
 
   private getMinimumResult(

--- a/src/tests/socialite-network-methods.test.ts
+++ b/src/tests/socialite-network-methods.test.ts
@@ -202,6 +202,22 @@ describe('Socialite network methods', () => {
     });
   });
 
+  describe('getNetworkFromDomain()', () => {
+    it('returns the requested network', () => {
+      const mockSocialite = new Socialite();
+
+      const network = mockSocialite.getNetworkFromDomain(networkFacebook.id);
+      expect(network).toStrictEqual(networkFacebook);
+    });
+
+    it('returns `undefined` if the network does not exist', () => {
+      const mockSocialite = new Socialite();
+
+      const network = mockSocialite.getNetwork('foo');
+      expect(network).toBeUndefined();
+    });
+  });
+
   describe('getPreferredUrl()', () => {
     it('returns the `preferredUrl` with only `user` replaced', () => {
       const mockSocialite = new Socialite();


### PR DESCRIPTION
What once was `private`, is now `public`.