### PR TITLE
✨ [Discord] Broader support for urls

### DIFF
--- a/.changeset/lazy-doors-stare.md
+++ b/.changeset/lazy-doors-stare.md
@@ -1,0 +1,5 @@
+---
+'socialitejs': patch
+---
+
+Support more variations for Discord urls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socialitejs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "socialitejs",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "devDependencies": {
         "@beefchimi/browserslist-config": "^0.0.9",
@@ -15,12 +15,12 @@
         "@beefchimi/typescript-config": "^0.0.9",
         "@changesets/changelog-github": "^0.4.3",
         "@changesets/cli": "^2.21.0",
-        "@types/node": "^17.0.19",
-        "@vitest/ui": "^0.5.3",
+        "@types/node": "^17.0.21",
+        "@vitest/ui": "^0.5.9",
         "c8": "^7.11.0",
-        "vite": "^2.8.4",
+        "vite": "^2.8.5",
         "vite-plugin-dts": "^0.9.9",
-        "vitest": "^0.5.3"
+        "vitest": "^0.5.9"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -786,9 +786,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1086,9 +1086,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
-      "integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1104,14 +1104,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz",
-      "integrity": "sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
+      "integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/type-utils": "5.12.1",
-        "@typescript-eslint/utils": "5.12.1",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/type-utils": "5.13.0",
+        "@typescript-eslint/utils": "5.13.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -1152,12 +1152,12 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.12.1.tgz",
-      "integrity": "sha512-4bEa8WrS5DdzJq43smPH12ys4AOoCxVu2xjYGXQR4DnNyM8pqNzCr28zodf38Jc4bxWdniSEKKC1bQaccXGq5Q==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.13.0.tgz",
+      "integrity": "sha512-A0btJxjB9gH6yJsARONe5xd0ykgj1+0fO1TRWoUBn2hT3haWiZeh4f1FILKW0z/9OBchT5zCOz3hiJfRK/vumA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.12.1"
+        "@typescript-eslint/utils": "5.13.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1171,14 +1171,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.1.tgz",
-      "integrity": "sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
+      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1198,13 +1198,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
-      "integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
+      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1"
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1215,12 +1215,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz",
-      "integrity": "sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
+      "integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.12.1",
+        "@typescript-eslint/utils": "5.13.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-      "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
+      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1254,13 +1254,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-      "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
+      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1296,15 +1296,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
-      "integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
+      "integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1320,12 +1320,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-      "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
+      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.12.1",
+        "@typescript-eslint/types": "5.13.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -1346,9 +1346,9 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.5.3.tgz",
-      "integrity": "sha512-8iicYgYLEPj31XpHkU8/X0w6kSLcf+b4EjJj02iF4VF3aWmomxG5DWnCxrx6B7ipb90XWgoaAwkU8Gy5YSdkOQ==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.5.9.tgz",
+      "integrity": "sha512-+Y51EhIuT4tonINzzBSjfEsaU4deGgUilTGaE2MP+9Co3WyPHr11byzSA1VEj7mYWJ204xxPY22ZYUCdX01Aag==",
       "dev": true,
       "dependencies": {
         "sirv": "^2.0.2"
@@ -2143,9 +2143,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.75",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
+      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
       "dev": true,
       "peer": true
     },
@@ -2584,13 +2584,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -3012,9 +3012,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
-      "integrity": "sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
+      "integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -3022,12 +3022,12 @@
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
         "object.hasown": "^1.1.0",
         "object.values": "^1.1.5",
-        "prop-types": "^15.7.2",
+        "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.6"
@@ -5150,12 +5150,12 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dev": true,
       "dependencies": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -6413,9 +6413,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -6519,9 +6519,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.4.tgz",
-      "integrity": "sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.5.tgz",
+      "integrity": "sha512-C/7EGNa1ugWejol6nOcd/0d8PR70Nzd+XXwsPbnNOfzZw0NN2xyXfmw/GNDHgr5fcaTSO4gjxCJCrwNhQUMhmA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.14",
@@ -6573,9 +6573,9 @@
       }
     },
     "node_modules/vite-plugin-dts/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6608,9 +6608,9 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.5.3.tgz",
-      "integrity": "sha512-tAV96lEUvycgiqsQKoQRjzXwDg+ae/R2jBLtt6MnFywOXbC9wYl+nRT9qT+d/+Mlw2B4dvVa9zuekY3emdcXJA==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.5.9.tgz",
+      "integrity": "sha512-R8lRP9Q1yIbwr8pDf2gvw4PFe8H5YMyHhBcdyfnUh6toLfCR10jrdI/WkNxdo5I4H/9XrMX9t+SAavdJExNdKg==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.0",
@@ -7482,9 +7482,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -7543,9 +7543,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -7743,9 +7743,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
-      "integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -7761,14 +7761,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz",
-      "integrity": "sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
+      "integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/type-utils": "5.12.1",
-        "@typescript-eslint/utils": "5.12.1",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/type-utils": "5.13.0",
+        "@typescript-eslint/utils": "5.13.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -7789,61 +7789,61 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.12.1.tgz",
-      "integrity": "sha512-4bEa8WrS5DdzJq43smPH12ys4AOoCxVu2xjYGXQR4DnNyM8pqNzCr28zodf38Jc4bxWdniSEKKC1bQaccXGq5Q==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.13.0.tgz",
+      "integrity": "sha512-A0btJxjB9gH6yJsARONe5xd0ykgj1+0fO1TRWoUBn2hT3haWiZeh4f1FILKW0z/9OBchT5zCOz3hiJfRK/vumA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.12.1"
+        "@typescript-eslint/utils": "5.13.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.1.tgz",
-      "integrity": "sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
+      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
-      "integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
+      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1"
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz",
-      "integrity": "sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
+      "integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.12.1",
+        "@typescript-eslint/utils": "5.13.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-      "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
+      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-      "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
+      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/visitor-keys": "5.12.1",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/visitor-keys": "5.13.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -7863,26 +7863,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
-      "integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
+      "integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.12.1",
-        "@typescript-eslint/types": "5.12.1",
-        "@typescript-eslint/typescript-estree": "5.12.1",
+        "@typescript-eslint/scope-manager": "5.13.0",
+        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/typescript-estree": "5.13.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-      "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
+      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.12.1",
+        "@typescript-eslint/types": "5.13.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "dependencies": {
@@ -7895,9 +7895,9 @@
       }
     },
     "@vitest/ui": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.5.3.tgz",
-      "integrity": "sha512-8iicYgYLEPj31XpHkU8/X0w6kSLcf+b4EjJj02iF4VF3aWmomxG5DWnCxrx6B7ipb90XWgoaAwkU8Gy5YSdkOQ==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.5.9.tgz",
+      "integrity": "sha512-+Y51EhIuT4tonINzzBSjfEsaU4deGgUilTGaE2MP+9Co3WyPHr11byzSA1VEj7mYWJ204xxPY22ZYUCdX01Aag==",
       "dev": true,
       "requires": {
         "sirv": "^2.0.2"
@@ -8519,9 +8519,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.75",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
+      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
       "dev": true,
       "peer": true
     },
@@ -8761,13 +8761,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -9186,9 +9186,9 @@
       "requires": {}
     },
     "eslint-plugin-react": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
-      "integrity": "sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
+      "integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -9196,12 +9196,12 @@
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
         "object.hasown": "^1.1.0",
         "object.values": "^1.1.5",
-        "prop-types": "^15.7.2",
+        "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.6"
@@ -10664,12 +10664,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -11629,9 +11629,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "peer": true
     },
@@ -11718,9 +11718,9 @@
       }
     },
     "vite": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.4.tgz",
-      "integrity": "sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.5.tgz",
+      "integrity": "sha512-C/7EGNa1ugWejol6nOcd/0d8PR70Nzd+XXwsPbnNOfzZw0NN2xyXfmw/GNDHgr5fcaTSO4gjxCJCrwNhQUMhmA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.14",
@@ -11742,9 +11742,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -11771,9 +11771,9 @@
       }
     },
     "vitest": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.5.3.tgz",
-      "integrity": "sha512-tAV96lEUvycgiqsQKoQRjzXwDg+ae/R2jBLtt6MnFywOXbC9wYl+nRT9qT+d/+Mlw2B4dvVa9zuekY3emdcXJA==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.5.9.tgz",
+      "integrity": "sha512-R8lRP9Q1yIbwr8pDf2gvw4PFe8H5YMyHhBcdyfnUh6toLfCR10jrdI/WkNxdo5I4H/9XrMX9t+SAavdJExNdKg==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "@beefchimi/typescript-config": "^0.0.9",
     "@changesets/changelog-github": "^0.4.3",
     "@changesets/cli": "^2.21.0",
-    "@types/node": "^17.0.19",
-    "@vitest/ui": "^0.5.3",
+    "@types/node": "^17.0.21",
+    "@vitest/ui": "^0.5.9",
     "c8": "^7.11.0",
-    "vite": "^2.8.4",
+    "vite": "^2.8.5",
     "vite-plugin-dts": "^0.9.9",
-    "vitest": "^0.5.3"
+    "vitest": "^0.5.9"
   }
 }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -39,3 +39,13 @@ export const defaultUserMatcher = {
   subdomain: /[^.]+/,
   path: /[^/]+/,
 };
+
+// TODO: This should probably be re-located elsewhere
+// https://github.com/beefchimi/socialite/issues/35
+export const discordPreferredUrls = {
+  users: `https://discordapp.com/users/${profileReplacement.user}`,
+  channels: `https://discord.com/channels/${profileReplacement.user}`,
+  vanity: `https://discord.gg/${profileReplacement.user}`,
+  // TODO: This result should not be supported
+  default: `https://discord.com/${profileReplacement.user}`,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,14 @@ export {
   filterNullishValuesFromObject,
   filterNetworkProperties,
   mergeRegExp,
+  getDiscordPreferredUrl,
   getUrlGroups,
   getUrlWithSubstitutions,
 } from './utilities';
 
 export {MatchUserSource, UrlCaptureId} from './types';
 export type {
+  DiscordUrlCriteria,
   UrlAnatomy,
   SocialiteNetwork,
   SocialiteProfile,

--- a/src/networks/discord.ts
+++ b/src/networks/discord.ts
@@ -1,11 +1,26 @@
-import {profileReplacement} from '../capture';
+import {discordPreferredUrls} from '../capture';
 import type {SocialiteNetwork} from '../types';
 
+// Discord is difficult to solve given Socialite's current design.
+// There are essentially 3 different urls to support:
+// 1. User profiles (discordapp.com/users/*)
+// 2. Server/channel urls (discord.com/channels/{serverid}/{channelid})
+// 3. Official vanity urls (discord.gg/*)
+// Since we are not yet validating against a Top-level domain (.gg),
+// any `discord` url validates as true and captures the `path`.
+// This degrades the confidence provided by `users` or `channels`.
+
+// TODO: Solve this problem by improving `preferredUrl` and parsing criteria.
+// https://github.com/beefchimi/socialite/issues/35
 export const discord: SocialiteNetwork = {
   id: 'discord',
-  preferredUrl: `https://discordapp.com/users/${profileReplacement.user}`,
+  preferredUrl: discordPreferredUrls.users,
   matcher: {
     domain: /discord/,
-    user: /^(?:\/users\/)([^/]+)/,
+    user: /^\/(?:users\/|channels\/)?([^/]+)/,
+    // TODO: If we want to support capturing EVERYTHING after
+    // the first `/` (necessary for capturing the `channelid`),
+    // then we would need to use the following:
+    // user: /^\/(?:users\/|channels\/)?(.+)/,
   },
 };

--- a/src/networks/tests/discord.test.ts
+++ b/src/networks/tests/discord.test.ts
@@ -1,38 +1,114 @@
 import {Socialite} from '../../socialite';
 import type {SocialiteProfile} from '../../types';
-import {allSocialiteNetworks, mockGenericUser} from '../../tests/fixtures';
+import {
+  allSocialiteNetworks,
+  discordValidUrls,
+  mockGenericUser,
+} from '../../tests/fixtures';
 import {discord} from '../discord';
 
 describe('Social networks > discord', () => {
   const mockSocialite = new Socialite(allSocialiteNetworks);
-  const mockCommonUrl = `https://www.discordapp.com/users/${mockGenericUser}`;
 
-  it('returns expected `id` and `user` from common url', () => {
-    const {id, user} = mockSocialite.parseProfile(
-      mockCommonUrl,
-    ) as SocialiteProfile;
+  // TODO: We want to resolve these in the future
+  // https://github.com/beefchimi/socialite/issues/35
+  describe('bogus', () => {
+    it('mistakenly returns the first path match for any `discord` url', () => {
+      const mockPageSlug = 'about-us-page';
+      const mockBogusUrl = `https://www.discord.com/${mockPageSlug}`;
 
-    expect(id).toBe(discord.id);
-    expect(user).toBe(mockGenericUser);
+      const {id, user} = mockSocialite.parseProfile(
+        mockBogusUrl,
+      ) as SocialiteProfile;
+
+      expect(id).toBe(discord.id);
+      expect(user).toBe(mockPageSlug);
+    });
   });
 
-  it('returns expected `id` and `user` from url with trailing path', () => {
-    const mockUncommonUrl = `${mockCommonUrl}/trail-123`;
-    const {id, user} = mockSocialite.parseProfile(
-      mockUncommonUrl,
-    ) as SocialiteProfile;
+  describe('users', () => {
+    const mockUsersUrl = `https://www.discordapp.com/users/${mockGenericUser}`;
 
-    expect(id).toBe(discord.id);
-    expect(user).toBe(mockGenericUser);
+    it('returns `id` and `user`', () => {
+      const {id, user} = mockSocialite.parseProfile(
+        mockUsersUrl,
+      ) as SocialiteProfile;
+
+      expect(id).toBe(discord.id);
+      expect(user).toBe(mockGenericUser);
+    });
+
+    it('omits any trailing path after the first `user` match', () => {
+      const mockUsersTrailingUrl = `${mockUsersUrl}/trail-123`;
+
+      const {id, user} = mockSocialite.parseProfile(
+        mockUsersTrailingUrl,
+      ) as SocialiteProfile;
+
+      expect(id).toBe(discord.id);
+      expect(user).toBe(mockGenericUser);
+    });
   });
 
-  it('returns `id` with no `user` when provided an unrecognized leading path', () => {
-    const mockUnsupportedUrl = `https://discordapp.com/foo/${mockGenericUser}`;
-    const match = mockSocialite.parseProfile(
-      mockUnsupportedUrl,
-    ) as SocialiteProfile;
+  describe('channels', () => {
+    const mockChannelsUrl = `https://www.discord.com/channels/${mockGenericUser}`;
 
-    expect(match.id).toBe(discord.id);
-    expect(match.user).toBeUndefined();
+    it('returns `id` and `user`', () => {
+      const {id, user} = mockSocialite.parseProfile(
+        mockChannelsUrl,
+      ) as SocialiteProfile;
+
+      expect(id).toBe(discord.id);
+      expect(user).toBe(mockGenericUser);
+    });
+
+    it('omits any trailing path after the first `user` match', () => {
+      const mockChannelsTrailingUrl = `${mockChannelsUrl}/trail-123`;
+
+      const {id, user} = mockSocialite.parseProfile(
+        mockChannelsTrailingUrl,
+      ) as SocialiteProfile;
+
+      expect(id).toBe(discord.id);
+      expect(user).toBe(mockGenericUser);
+    });
+  });
+
+  describe('vanity', () => {
+    const mockVanityUrl = `https://discord.gg/${mockGenericUser}`;
+
+    it('returns `id` and `user`', () => {
+      const {id, user} = mockSocialite.parseProfile(
+        mockVanityUrl,
+      ) as SocialiteProfile;
+
+      expect(id).toBe(discord.id);
+      expect(user).toBe(mockGenericUser);
+    });
+
+    it('omits any trailing path after the first `user` match', () => {
+      const mockVanityTrailingUrl = `${mockVanityUrl}/trail-123`;
+
+      const {id, user} = mockSocialite.parseProfile(
+        mockVanityTrailingUrl,
+      ) as SocialiteProfile;
+
+      expect(id).toBe(discord.id);
+      expect(user).toBe(mockGenericUser);
+    });
+  });
+
+  describe('all variations', () => {
+    it('returns `id` and `user`', () => {
+      discordValidUrls.forEach(({originalUrl, preferredUrl, user}) => {
+        const match = mockSocialite.parseProfile(
+          originalUrl,
+        ) as SocialiteProfile;
+
+        expect(match.id).toBe(discord.id);
+        expect(match.preferredUrl).toBe(preferredUrl);
+        expect(match.user).toBe(user);
+      });
+    });
   });
 });

--- a/src/socialite.ts
+++ b/src/socialite.ts
@@ -4,6 +4,7 @@ import {defaultUserMatcher, schemeRegExp} from './capture';
 import {MatchUserSource} from './types';
 import type {
   BasicUrl,
+  DiscordProfile,
   NetworkId,
   NetworkMap,
   ParsedUrlGroups,
@@ -15,6 +16,7 @@ import type {
 } from './types';
 import {
   filterNetworkProperties,
+  getDiscordPreferredUrl,
   getUrlGroups,
   getUrlWithSubstitutions,
 } from './utilities';
@@ -155,11 +157,13 @@ export class Socialite {
       return minResult;
     }
 
-    const preferredUrl = getUrlWithSubstitutions(
-      targetNetwork.preferredUrl,
-      user,
-      prefix,
-    );
+    // TODO: Resolve this special condition
+    // https://github.com/beefchimi/socialite/issues/35
+    const preferredUrl =
+      targetNetwork.id === 'discord'
+        ? getDiscordPreferredUrl({...minResult, user} as DiscordProfile)
+        : getUrlWithSubstitutions(targetNetwork.preferredUrl, user, prefix);
+
     const appUrl = targetNetwork.appUrl
       ? getUrlWithSubstitutions(targetNetwork.appUrl, user, prefix)
       : undefined;

--- a/src/socialite.ts
+++ b/src/socialite.ts
@@ -4,7 +4,6 @@ import {defaultUserMatcher, schemeRegExp} from './capture';
 import {MatchUserSource} from './types';
 import type {
   BasicUrl,
-  DiscordProfile,
   NetworkId,
   NetworkMap,
   ParsedUrlGroups,
@@ -161,7 +160,11 @@ export class Socialite {
     // https://github.com/beefchimi/socialite/issues/35
     const preferredUrl =
       targetNetwork.id === 'discord'
-        ? getDiscordPreferredUrl({...minResult, user} as DiscordProfile)
+        ? getDiscordPreferredUrl({
+            tldomain: minResult.urlGroups.tldomain,
+            path: minResult.urlGroups.path,
+            user,
+          })
         : getUrlWithSubstitutions(targetNetwork.preferredUrl, user, prefix);
 
     const appUrl = targetNetwork.appUrl

--- a/src/tests/fixtures/discord-urls.ts
+++ b/src/tests/fixtures/discord-urls.ts
@@ -1,0 +1,186 @@
+export const discordValidUrls = [
+  {
+    originalUrl: 'https://discord.com/users/username',
+    preferredUrl: 'https://discordapp.com/users/username',
+    user: 'username',
+  },
+  {
+    originalUrl: 'http://discordapp.com/users/0123456789',
+    preferredUrl: 'https://discordapp.com/users/0123456789',
+    user: '0123456789',
+  },
+  {
+    originalUrl: 'https://discord.com/channels/@me',
+    preferredUrl: 'https://discord.com/channels/@me',
+    user: '@me',
+  },
+  {
+    originalUrl: 'http://discord.com/channels/892738558316662855',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl:
+      'https://discord.com/channels/892738558316662855/892738558996148236',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl: 'http://discordapp.com/channels/serverid/channelid/messageid',
+    preferredUrl: 'https://discord.com/channels/serverid',
+    user: 'serverid',
+  },
+  {
+    originalUrl: 'https://discord.gg/vanity-url',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'http://discord.gg/vanity-url/0123456789',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'https://discordapp.gg/0123456789',
+    preferredUrl: 'https://discord.gg/0123456789',
+    user: '0123456789',
+  },
+  {
+    originalUrl: 'http://www.discord.com/users/username',
+    preferredUrl: 'https://discordapp.com/users/username',
+    user: 'username',
+  },
+  {
+    originalUrl: 'https://www.discordapp.com/users/0123456789',
+    preferredUrl: 'https://discordapp.com/users/0123456789',
+    user: '0123456789',
+  },
+  {
+    originalUrl: 'http://www.discord.com/channels/@me',
+    preferredUrl: 'https://discord.com/channels/@me',
+    user: '@me',
+  },
+  {
+    originalUrl: 'https://www.discord.com/channels/892738558316662855',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl:
+      'http://www.discord.com/channels/892738558316662855/892738558996148236',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl:
+      'https://www.discordapp.com/channels/serverid/channelid/messageid',
+    preferredUrl: 'https://discord.com/channels/serverid',
+    user: 'serverid',
+  },
+  {
+    originalUrl: 'http://www.discord.gg/vanity-url',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'https://www.discord.gg/vanity-url/0123456789',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'http://www.discordapp.gg/0123456789',
+    preferredUrl: 'https://discord.gg/0123456789',
+    user: '0123456789',
+  },
+  {
+    originalUrl: 'www.discord.com/users/username',
+    preferredUrl: 'https://discordapp.com/users/username',
+    user: 'username',
+  },
+  {
+    originalUrl: 'sub.discordapp.com/users/0123456789',
+    preferredUrl: 'https://discordapp.com/users/0123456789',
+    user: '0123456789',
+  },
+  {
+    originalUrl: 'www.discord.com/channels/@me',
+    preferredUrl: 'https://discord.com/channels/@me',
+    user: '@me',
+  },
+  {
+    originalUrl: 'sub1.sub2.discord.com/channels/892738558316662855',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl:
+      'www.discord.com/channels/892738558316662855/892738558996148236',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl: 'sub.discordapp.com/channels/serverid/channelid/messageid',
+    preferredUrl: 'https://discord.com/channels/serverid',
+    user: 'serverid',
+  },
+  {
+    originalUrl: 'www.discord.gg/vanity-url',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'sub1.sub2.discord.gg/vanity-url/0123456789',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'www.discordapp.gg/0123456789',
+    preferredUrl: 'https://discord.gg/0123456789',
+    user: '0123456789',
+  },
+  {
+    originalUrl: 'discord.com/users/username',
+    preferredUrl: 'https://discordapp.com/users/username',
+    user: 'username',
+  },
+  {
+    originalUrl: 'discordapp.com/users/0123456789',
+    preferredUrl: 'https://discordapp.com/users/0123456789',
+    user: '0123456789',
+  },
+  {
+    originalUrl: 'discord.com/channels/@me',
+    preferredUrl: 'https://discord.com/channels/@me',
+    user: '@me',
+  },
+  {
+    originalUrl: 'discord.com/channels/892738558316662855',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl: 'discord.com/channels/892738558316662855/892738558996148236',
+    preferredUrl: 'https://discord.com/channels/892738558316662855',
+    user: '892738558316662855',
+  },
+  {
+    originalUrl: 'discordapp.com/channels/serverid/channelid/messageid',
+    preferredUrl: 'https://discord.com/channels/serverid',
+    user: 'serverid',
+  },
+  {
+    originalUrl: 'discord.gg/vanity-url',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'discord.gg/vanity-url/0123456789',
+    preferredUrl: 'https://discord.gg/vanity-url',
+    user: 'vanity-url',
+  },
+  {
+    originalUrl: 'discordapp.gg/0123456789',
+    preferredUrl: 'https://discord.gg/0123456789',
+    user: '0123456789',
+  },
+];

--- a/src/tests/fixtures/index.ts
+++ b/src/tests/fixtures/index.ts
@@ -1,5 +1,7 @@
 export {allSocialiteNetworks, mockCustomNetworks} from './networks';
 
+export {discordValidUrls} from './discord-urls';
+
 export {invalidProfileUrls} from './invalid-profiles';
 export {
   mockGenericUser,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,4 +16,4 @@ export type {
   SocialiteNetworkProperties,
 } from './social-network';
 
-export type {DiscordProfile, SocialiteProfile} from './social-profile';
+export type {DiscordUrlCriteria, SocialiteProfile} from './social-profile';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,4 +16,4 @@ export type {
   SocialiteNetworkProperties,
 } from './social-network';
 
-export type {SocialiteProfile} from './social-profile';
+export type {DiscordProfile, SocialiteProfile} from './social-profile';

--- a/src/types/social-profile.ts
+++ b/src/types/social-profile.ts
@@ -11,6 +11,8 @@ export interface SocialiteProfile {
   prefix?: UserPrefix;
 }
 
-export interface DiscordProfile extends SocialiteProfile {
-  id: 'discord';
+export interface DiscordUrlCriteria {
+  tldomain?: UrlAnatomy['tldomain'];
+  path?: UrlAnatomy['path'];
+  user?: UserName;
 }

--- a/src/types/social-profile.ts
+++ b/src/types/social-profile.ts
@@ -10,3 +10,7 @@ export interface SocialiteProfile {
   user?: UserName;
   prefix?: UserPrefix;
 }
+
+export interface DiscordProfile extends SocialiteProfile {
+  id: 'discord';
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,4 +1,8 @@
 export {filterNullishValuesFromObject} from './general';
 export {filterNetworkProperties} from './network';
 export {mergeRegExp} from './regexp';
-export {getUrlGroups, getUrlWithSubstitutions} from './url';
+export {
+  getUrlGroups,
+  getUrlWithSubstitutions,
+  getDiscordPreferredUrl,
+} from './url';

--- a/src/utilities/tests/fixtures.ts
+++ b/src/utilities/tests/fixtures.ts
@@ -1,4 +1,5 @@
 import {profileReplacement} from '../../capture';
+import type {DiscordProfile} from '../../types';
 
 export const mockObject = {
   one: 1,
@@ -26,3 +27,43 @@ export const mockFullUrl =
 export const mockPartialUrl = 'http://website.ca?query=param';
 
 export const mockReplacementUrl = `https://domain.com/${profileReplacement.prefix}${profileReplacement.user}`;
+
+export const mockDiscordUsersProfile: DiscordProfile = {
+  id: 'discord',
+  urlGroups: {
+    domain: 'discordapp',
+    tldomain: '.com',
+    scheme: 'https://',
+    subdomain: 'www.',
+    path: '/users/username',
+  },
+  originalUrl: 'https://www.discordapp.com/users/username',
+  preferredUrl: 'https://discordapp.com/users/username',
+  user: 'username',
+};
+
+export const mockDiscordChannelsProfile: DiscordProfile = {
+  id: 'discord',
+  urlGroups: {
+    domain: 'discord',
+    tldomain: '.com',
+    scheme: 'http',
+    subdomain: 'www.',
+    path: '/channels/foo',
+  },
+  originalUrl: 'http://www.discord.com/channels/foo',
+  preferredUrl: 'https://discord.com/channels/foo',
+  user: 'foo',
+};
+
+export const mockDiscordVanityProfile: DiscordProfile = {
+  id: 'discord',
+  urlGroups: {
+    domain: 'discord',
+    tldomain: '.gg',
+    path: '/bar123',
+  },
+  originalUrl: 'discord.gg/bar123',
+  preferredUrl: 'https://discord.gg/bar123',
+  user: 'bar123',
+};

--- a/src/utilities/tests/fixtures.ts
+++ b/src/utilities/tests/fixtures.ts
@@ -1,5 +1,5 @@
 import {profileReplacement} from '../../capture';
-import type {DiscordProfile} from '../../types';
+import type {DiscordUrlCriteria} from '../../types';
 
 export const mockObject = {
   one: 1,
@@ -28,42 +28,20 @@ export const mockPartialUrl = 'http://website.ca?query=param';
 
 export const mockReplacementUrl = `https://domain.com/${profileReplacement.prefix}${profileReplacement.user}`;
 
-export const mockDiscordUsersProfile: DiscordProfile = {
-  id: 'discord',
-  urlGroups: {
-    domain: 'discordapp',
-    tldomain: '.com',
-    scheme: 'https://',
-    subdomain: 'www.',
-    path: '/users/username',
-  },
-  originalUrl: 'https://www.discordapp.com/users/username',
-  preferredUrl: 'https://discordapp.com/users/username',
+export const mockDiscordUsersProfile: DiscordUrlCriteria = {
+  tldomain: '.com',
+  path: '/users/username',
   user: 'username',
 };
 
-export const mockDiscordChannelsProfile: DiscordProfile = {
-  id: 'discord',
-  urlGroups: {
-    domain: 'discord',
-    tldomain: '.com',
-    scheme: 'http',
-    subdomain: 'www.',
-    path: '/channels/foo',
-  },
-  originalUrl: 'http://www.discord.com/channels/foo',
-  preferredUrl: 'https://discord.com/channels/foo',
+export const mockDiscordChannelsProfile: DiscordUrlCriteria = {
+  tldomain: '.com',
+  path: '/channels/foo',
   user: 'foo',
 };
 
-export const mockDiscordVanityProfile: DiscordProfile = {
-  id: 'discord',
-  urlGroups: {
-    domain: 'discord',
-    tldomain: '.gg',
-    path: '/bar123',
-  },
-  originalUrl: 'discord.gg/bar123',
-  preferredUrl: 'https://discord.gg/bar123',
+export const mockDiscordVanityProfile: DiscordUrlCriteria = {
+  tldomain: '.gg',
+  path: '/bar123',
   user: 'bar123',
 };

--- a/src/utilities/tests/url.test.ts
+++ b/src/utilities/tests/url.test.ts
@@ -1,5 +1,16 @@
-import {getUrlGroups, getUrlWithSubstitutions} from '../url';
-import {mockFullUrl, mockPartialUrl, mockReplacementUrl} from './fixtures';
+import {
+  getUrlGroups,
+  getUrlWithSubstitutions,
+  getDiscordPreferredUrl,
+} from '../url';
+import {
+  mockFullUrl,
+  mockPartialUrl,
+  mockReplacementUrl,
+  mockDiscordUsersProfile,
+  mockDiscordChannelsProfile,
+  mockDiscordVanityProfile,
+} from './fixtures';
 
 describe('Url utilities', () => {
   describe('getUrlGroups()', () => {
@@ -72,6 +83,29 @@ describe('Url utilities', () => {
         mockPrefix,
       );
       expect(result).toBe(`https://domain.com/${mockPrefix}${mockUser}`);
+    });
+  });
+
+  describe('getDiscordPreferredUrl()', () => {
+    it('returns `preferredUrl` for `users`', () => {
+      const result = getDiscordPreferredUrl(mockDiscordUsersProfile);
+      expect(result).toBe(
+        `https://discordapp.com/users/${mockDiscordUsersProfile.user}`,
+      );
+    });
+
+    it('returns `preferredUrl` for `channels`', () => {
+      const result = getDiscordPreferredUrl(mockDiscordChannelsProfile);
+      expect(result).toBe(
+        `https://discord.com/channels/${mockDiscordChannelsProfile.user}`,
+      );
+    });
+
+    it('returns `preferredUrl` for `vanity`', () => {
+      const result = getDiscordPreferredUrl(mockDiscordVanityProfile);
+      expect(result).toBe(
+        `https://discord.gg/${mockDiscordVanityProfile.user}`,
+      );
     });
   });
 });

--- a/src/utilities/url.ts
+++ b/src/utilities/url.ts
@@ -1,5 +1,10 @@
-import {profileReplacement, urlRegExp} from '../capture';
-import type {BasicUrl, UrlGroupSubset, ParsedUrlGroups} from '../types';
+import {discordPreferredUrls, profileReplacement, urlRegExp} from '../capture';
+import type {
+  BasicUrl,
+  DiscordProfile,
+  UrlGroupSubset,
+  ParsedUrlGroups,
+} from '../types';
 import {filterNullishValuesFromObject} from './general';
 
 function updateGroupsWithSubdomain(groups: UrlGroupSubset): UrlGroupSubset {
@@ -41,4 +46,21 @@ export function getUrlWithSubstitutions(url: BasicUrl, user = '', prefix = '') {
   return url
     .replace(profileReplacement.user, user)
     .replace(profileReplacement.prefix, prefix);
+}
+
+export function getDiscordPreferredUrl({urlGroups, user}: DiscordProfile) {
+  if (urlGroups.path?.startsWith('/users/')) {
+    return getUrlWithSubstitutions(discordPreferredUrls.users, user);
+  }
+
+  if (urlGroups.path?.startsWith('/channels/')) {
+    return getUrlWithSubstitutions(discordPreferredUrls.channels, user);
+  }
+
+  if (urlGroups.tldomain === '.gg') {
+    return getUrlWithSubstitutions(discordPreferredUrls.vanity, user);
+  }
+
+  // Currently, there are no other supported URLs (such as a `appUrl`).
+  return getUrlWithSubstitutions(discordPreferredUrls.default, user);
 }

--- a/src/utilities/url.ts
+++ b/src/utilities/url.ts
@@ -1,7 +1,7 @@
 import {discordPreferredUrls, profileReplacement, urlRegExp} from '../capture';
 import type {
   BasicUrl,
-  DiscordProfile,
+  DiscordUrlCriteria,
   UrlGroupSubset,
   ParsedUrlGroups,
 } from '../types';
@@ -48,16 +48,20 @@ export function getUrlWithSubstitutions(url: BasicUrl, user = '', prefix = '') {
     .replace(profileReplacement.prefix, prefix);
 }
 
-export function getDiscordPreferredUrl({urlGroups, user}: DiscordProfile) {
-  if (urlGroups.path?.startsWith('/users/')) {
+export function getDiscordPreferredUrl({
+  tldomain,
+  path,
+  user,
+}: DiscordUrlCriteria) {
+  if (path?.startsWith('/users/')) {
     return getUrlWithSubstitutions(discordPreferredUrls.users, user);
   }
 
-  if (urlGroups.path?.startsWith('/channels/')) {
+  if (path?.startsWith('/channels/')) {
     return getUrlWithSubstitutions(discordPreferredUrls.channels, user);
   }
 
-  if (urlGroups.tldomain === '.gg') {
+  if (tldomain === '.gg') {
     return getUrlWithSubstitutions(discordPreferredUrls.vanity, user);
   }
 


### PR DESCRIPTION
This PR attempts to support a few more variations for `discord` URLS - albeit with limitations.
1. `discordapp.xyz/users/*` _(was already supported)_
2. `discord.xyz/channels/*`
3. `discord.gg/*`

These two new urls unfortunately make `preferredUrl` unreliable. As such, I've had to add some snowflake code so that we can detect `discord` and call a special function just for retrieving 1 of 3 _(4 if you count the fallback)_ preferred URLs.

At some point, we will likely want to revise how `preferredUrl` _(and `appUrl`)_ work for all networks. There is a bit more context [in this issue for Discord](https://github.com/beefchimi/socialite/issues/35).

Lastly, I've done a few small dependency bumps... this has resulted in a TypeScript warning because a `dev-configs` dependency does not include the latest TypeScript version in its support range. So far, there does not appear to be any issues... but its something I should resolve.